### PR TITLE
Fix: vitest ignore node_modules

### DIFF
--- a/packages/eslint-plugin-example-typed-linting/vitest.config.ts
+++ b/packages/eslint-plugin-example-typed-linting/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    exclude: ["lib"],
+    exclude: ["lib", "node_modules"],
   },
 });


### PR DESCRIPTION
I don't know if this project must be run with all packages together, but when I tried to run only specific package on its own folder, I needed to ignore the "node_modules" folder.
